### PR TITLE
Added additional tests for erroneous AMT data

### DIFF
--- a/src/main/java/au/gov/digitalhealth/terminology/amtflatfile/Concept.java
+++ b/src/main/java/au/gov/digitalhealth/terminology/amtflatfile/Concept.java
@@ -13,14 +13,16 @@ public class Concept {
     private long id;
     private String fullSpecifiedName;
     private String preferredTerm;
-    private Set<Concept> units;
+    private Set<Concept> units = new HashSet<>();
     private Map<Long, Concept> parents = new HashMap<>();
     private Map<Long, Concept> ancestors = new HashMap<>();
-    private Set<Concept> tps;
-    private Set<String> artgIds;
+    private Set<Concept> tps = new HashSet<>();
+    private Set<String> artgIds = new HashSet<>();
+    private boolean active;
 
-    public Concept(long id) {
+    public Concept(long id, boolean active) {
         this.id = id;
+        this.active = active;
     }
 
     public void addParent(Concept concept) {
@@ -157,5 +159,9 @@ public class Concept {
 
     public Set<String> getArtgIds() {
         return artgIds;
+    }
+
+    public boolean isActive() {
+        return active;
     }
 }

--- a/src/main/java/au/gov/digitalhealth/terminology/amtflatfile/JUnitTestSuite_EXT.java
+++ b/src/main/java/au/gov/digitalhealth/terminology/amtflatfile/JUnitTestSuite_EXT.java
@@ -108,5 +108,15 @@ public class JUnitTestSuite_EXT extends JUnitTestSuite {
 		}
 		
 	}
+
+    public void addTestCase(String message, String detail, String testCaseName, String failType) {
+        JUnitFailure fail = new JUnitFailure();
+        fail.setMessage(message);
+        fail.setValue(detail);
+        fail.setType(failType);
+        JUnitTestCase_EXT testCase = new JUnitTestCase_EXT().setName(testCaseName);
+        testCase.addFailure(fail);
+        this.addTestCase(testCase);
+    }
 	
 }

--- a/src/test/java/au/gov/digitalhealth/terminology/amtflatfile/Amt2FlatFileTest.java
+++ b/src/test/java/au/gov/digitalhealth/terminology/amtflatfile/Amt2FlatFileTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 public class Amt2FlatFileTest {
-	
+
 	private String testResDirectory = "src/test/resources/";
 	private String inFile = testResDirectory + "NCTS_SCT_RF2_DISTRIBUTION_32506021000036107-20180430-SNAPSHOT.zip";
     private String outFile = "target/test-out/out.csv";
@@ -42,7 +42,7 @@ public class Amt2FlatFileTest {
 	
 	@Test(groups="files", priority = 1, description = "Tests that the JUnit file gets generated")
 	public void JUnitGenerated() throws MojoExecutionException, MojoFailureException, IOException {
-		Amt2FlatFile amt2FlatFile = new Amt2FlatFile();
+	    Amt2FlatFile amt2FlatFile = new Amt2FlatFile();
         amt2FlatFile.setInputZipFilePath("target/test-classes/rf2-fails-flat-file-generation-1.0.zip");
         amt2FlatFile.setOutputFilePath(outFile);
 		amt2FlatFile.execute();
@@ -55,13 +55,14 @@ public class Amt2FlatFileTest {
 		Amt2FlatFile amt2FlatFile = new Amt2FlatFile();
 		amt2FlatFile.setInputZipFilePath("target/test-classes/rf2-fails-flat-file-generation-1.0.zip");
 		amt2FlatFile.setOutputFilePath(outFile);
+        amt2FlatFile.setJunitFilePath("target/JUnitContainsCorrectErrors.xml");
 		amt2FlatFile.execute();
-		File validXml = new File("target/ValidationErrors.xml");
+        File validXml = new File("target/JUnitContainsCorrectErrors.xml");
 		JUnitTestSuite info = JUnitMarshalling.unmarshalTestSuite(new FileInputStream(validXml));
 		List<String> failures = info.getTestCases().stream().flatMap(aCase -> aCase.getFailures().stream().map(fail -> fail.getValue())).collect(Collectors.toList());
 		Assert.assertTrue(failures.stream().anyMatch(fail -> fail.contains("1212261000168108")));
 		Assert.assertTrue(failures.stream().anyMatch(fail -> fail.contains("1209811000168100")));
-        Assert.assertEquals(failures.size(), 8);
+        Assert.assertEquals(failures.size(), 10);
 	}
 	
 	
@@ -73,12 +74,11 @@ public class Amt2FlatFileTest {
 		amt2FlatFile.setOutputFilePath(outFile);
 		amt2FlatFile.execute();
 
-
 	}
 	
 	@Test(groups="files", priority = 1, description = "An exception is thrown when the provided input zip file is missing critical files", expectedExceptions=NullPointerException.class)
 	public void fileMissingFromReleaseExceptionThrown() throws MojoExecutionException, MojoFailureException, IOException {
-		  
+
 		Amt2FlatFile amt2FlatFile = new Amt2FlatFile();
 		amt2FlatFile.setInputZipFilePath(testResDirectory + "incomplete.zip");
 		amt2FlatFile.setOutputFilePath(outFile);


### PR DESCRIPTION
The flat file generator now can step over and report on erroneous AMT data so it doesn't block CI builds. However it will abort if "exitOnError" is set for any of these conditions

### Definition of Done

* [x] Code has been peer reviewed
* [x] Test coverage has been maintained or improved
* [x] All tests pass within CI
* [x] README is up to date
